### PR TITLE
Add warnings for missing API keys

### DIFF
--- a/src/js/components/interaction.js
+++ b/src/js/components/interaction.js
@@ -59,6 +59,20 @@ window.sendMessage = async function() {
     // Get API endpoint and prepare request data
     const apiEndpoint = window.getApiEndpoint();
     const { requestBody, headers } = window.prepareRequestData(message);
+
+    // Ensure an API key is configured before proceeding (except for Ollama)
+    const currentService = window.config.defaultService;
+    const apiKey = window.config.getApiKey ? window.config.getApiKey() : null;
+    if (!apiKey && currentService !== 'ollama') {
+      // Remove the loading indicator and warn the user
+      window.removeLoadingIndicator(loadingId);
+      if (window.showWarning) {
+        const name = currentService.charAt(0).toUpperCase() + currentService.slice(1);
+        window.showWarning(`${name} API key is missing. Please add it in the API Keys settings.`);
+      }
+      return;
+    }
+
     if (window.VERBOSE_LOGGING) console.info('API request prepared:', { apiEndpoint, requestBody, headers });
 
     // Check if function calling is enabled and toolDefinitions exists with actual tools

--- a/src/js/init/eventListeners.js
+++ b/src/js/init/eventListeners.js
@@ -447,6 +447,9 @@ function setupSelectorEventListeners() {
       const selectedService = window.serviceSelector.value;
       
       window.config.defaultService = selectedService;
+      if (typeof window.ensureApiKeysLoaded === 'function') {
+        window.ensureApiKeysLoaded();
+      }
       window.updateModelSelector();
       window.updateParameterControls();
       window.updateHeaderInfo();

--- a/src/js/services/apiKeys.js
+++ b/src/js/services/apiKeys.js
@@ -428,6 +428,30 @@ window.getOllamaServerUrl = function() {
 };
 
 /**
+ * Ensure API keys are loaded and warn if missing
+ */
+window.ensureApiKeysLoaded = function() {
+    // Load keys if not already loaded
+    if (typeof window.loadApiKeys === 'function') {
+        window.loadApiKeys();
+    }
+
+    if (!window.config || !window.config.services) return;
+
+    const service = window.config.defaultService;
+    const apiKey = window.getApiKey ? window.getApiKey(service) : null;
+
+    // Track warnings to avoid repetition
+    window._shownApiKeyWarnings = window._shownApiKeyWarnings || new Set();
+
+    if (!apiKey && window.showWarning && !window._shownApiKeyWarnings.has(service)) {
+        const name = service.charAt(0).toUpperCase() + service.slice(1);
+        window.showWarning(`${name} API key is missing. Please add it in the API Keys settings.`);
+        window._shownApiKeyWarnings.add(service);
+    }
+};
+
+/**
  * Show status message in the API keys tab
  * @param {string} message - The message to show
  * @param {string} type - The type of message ('success' or 'error')

--- a/src/js/services/apiKeys.js
+++ b/src/js/services/apiKeys.js
@@ -439,6 +439,10 @@ window.ensureApiKeysLoaded = function() {
     if (!window.config || !window.config.services) return;
 
     const service = window.config.defaultService;
+
+    // Skip warning for services that don't require a key (e.g., Ollama)
+    if (service === 'ollama') return;
+
     const apiKey = window.getApiKey ? window.getApiKey(service) : null;
 
     // Track warnings to avoid repetition


### PR DESCRIPTION
## Summary
- warn users when the selected service does not have an API key configured
- check for missing API keys when switching services

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6848c2718e8883278e01a010c66110a1